### PR TITLE
Fix EACCES when packing small molecules with read-only .lt sources

### DIFF
--- a/AutoPoly/pipeline/packer.py
+++ b/AutoPoly/pipeline/packer.py
@@ -192,12 +192,21 @@ class BoxPacker:
             return
 
         units.validate(build_dir)
+        # Source .lt files may be read-only (e.g. restaged from an immutable
+        # artifact store); copy2 preserves that mode, so force each working
+        # copy writable, and skip unit files already copied as monomer files
+        # (a molecule is listed in both) — re-copying onto the read-only
+        # destination would fail with EACCES.
         for rel in units.monomer_files:
-            shutil.copy2(build_dir / rel, self.moltemplate_dir / rel)
+            dst = self.moltemplate_dir / rel
+            shutil.copy2(build_dir / rel, dst)
+            dst.chmod(0o644)
         for unit in units.units:
             src = build_dir / unit.lt_file
-            if src.is_file():
-                shutil.copy2(src, self.moltemplate_dir / unit.lt_file)
+            dst = self.moltemplate_dir / unit.lt_file
+            if src.is_file() and not dst.exists():
+                shutil.copy2(src, dst)
+                dst.chmod(0o644)
 
         # External substrate slab: user-supplied .lt, imported as-is
         if self.substrate is not None and self.substrate.is_external:
@@ -206,7 +215,9 @@ class BoxPacker:
                 raise WorkflowError(
                     f"External substrate lt_file not found: {src}"
                 )
-            shutil.copy2(src, self.moltemplate_dir / src.name)
+            dst = self.moltemplate_dir / src.name
+            shutil.copy2(src, dst)
+            dst.chmod(0o644)
 
         # Built-in substrate slab: generate the .lt at pack time
         if self.substrate is not None and self.substrate.is_builder:

--- a/tests/unit/test_packing.py
+++ b/tests/unit/test_packing.py
@@ -225,3 +225,60 @@ class TestBoxPacker:
         os.remove(victim)
         with pytest.raises(ValidationError, match="missing"):
             BoxPacker(system, "proj", run_moltemplate=False).pack(library)
+
+
+class TestPrepareMoltemplateDir:
+    """Regression tests for _prepare_moltemplate_dir with read-only sources.
+
+    Artifact stores (e.g. m3flow) restage build/<ff>/ files read-only, and a
+    small molecule is listed both in monomer_files and as a unit — the copy
+    loops must not re-copy onto a read-only destination, and working copies
+    must be writable for downstream in-place processing.
+    """
+
+    @staticmethod
+    def _molecule_library():
+        return UnitLibrary(
+            force_field="oplsaa",
+            units=[UnitSpec(id="ethanol", kind="molecule", lt_file="ethanol.lt",
+                            count=500, radius=3.0)],
+            # a molecule appears in both lists (monomer for the FF subset,
+            # unit for placement)
+            monomer_files=["ethanol.lt"],
+            build_config={},
+        )
+
+    @staticmethod
+    def _readonly_build_dir(tmp_path):
+        build_dir = tmp_path / "build" / "oplsaa"
+        build_dir.mkdir(parents=True)
+        src = build_dir / "ethanol.lt"
+        src.write_text('Ethanol inherits OPLSAA {\n}\n')
+        src.chmod(0o444)
+        return build_dir
+
+    def test_readonly_molecule_lt_copied_once_writable(self, tmp_path):
+        system = System(out=str(tmp_path / "out"))
+        library = self._molecule_library()
+        build_dir = self._readonly_build_dir(tmp_path)
+        packer = BoxPacker(system, "proj", strategy="grid", run_moltemplate=False)
+
+        # Must not raise PermissionError re-copying onto the read-only copy
+        packer._prepare_moltemplate_dir(library, build_dir)
+
+        dst = packer.moltemplate_dir / "ethanol.lt"
+        assert dst.is_file()
+        assert dst.read_text() == (build_dir / "ethanol.lt").read_text()
+        assert dst.stat().st_mode & 0o200  # owner-writable working copy
+
+    def test_reprepare_after_failed_pack(self, tmp_path):
+        # Box-expansion retry re-prepares the dir; leftover copies must not
+        # break the second attempt.
+        system = System(out=str(tmp_path / "out"))
+        library = self._molecule_library()
+        build_dir = self._readonly_build_dir(tmp_path)
+        packer = BoxPacker(system, "proj", strategy="grid", run_moltemplate=False)
+
+        packer._prepare_moltemplate_dir(library, build_dir)
+        packer._prepare_moltemplate_dir(library, build_dir)
+        assert (packer.moltemplate_dir / "ethanol.lt").is_file()


### PR DESCRIPTION
## Problem

Packing a small-molecule system fails deterministically when the typed `.lt` files in `build/<ff>/` are read-only — the normal case when m3flow restages them from its immutable artifact store:

```
BoxPacker failed after box expansion attempts:
[Errno 13] Permission denied: '.../moltemplate/ethanol.lt'
```

(The message mentions box-expansion retries, but the retry loop only re-raises the last exception — the failure happens on the **first** attempt.)

## Root cause

In `_prepare_moltemplate_dir`:

1. For a `molecule` component, `units.json` lists its `.lt` file in **both** `monomer_files` (force-field subsetting) and `units[].lt_file` (placement). The two copy loops therefore copy the same source file to the same destination twice.
2. `shutil.copy2` preserves permission bits, so the first copy lands read-only; the second copy's `open(dst, 'wb')` raises `EACCES`.

Polymer systems never hit this because their unit `.lt` files are distinct from the monomer files. Run standalone (writable `build/` dir), the double-copy silently succeeds — which is why it stayed latent until an artifact store made sources read-only.

## Fix

- Skip a unit `.lt` copy when the file is already in place from the `monomer_files` loop.
- `chmod 0o644` every copied `.lt` (film monomers/units and external substrate): files in `moltemplate/` are working copies and must be writable — this also hardens the box-expansion retry path and `mv_files`, which would otherwise propagate the read-only mode up to the project dir and fail on overwrite there.

## Tests

Two regression tests in `tests/unit/test_packing.py` (`TestPrepareMoltemplateDir`):

- read-only molecule manifest listed in both `monomer_files` and `units` → prepare succeeds, content intact, working copy owner-writable
- re-preparing the dir (box-expansion retry) over read-only leftovers succeeds

`pytest tests/unit` — **572 passed**.

Verified end-to-end via m3flow `construct_system` on a 500-molecule ethanol bulk (OPLS-AA), which previously failed at the packing step and now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)